### PR TITLE
Removes the thumbnailing

### DIFF
--- a/layouts/shortcodes/glightbox.html
+++ b/layouts/shortcodes/glightbox.html
@@ -7,11 +7,7 @@
      data-glightbox="title:{{ .Get "title" | default "" }};description:{{ .Get "description" | default "" }}"
    {{end}}
 >
-<img {{ if .Get "gallery"}} 
-        src = "https://micro.blog/photos/360x/{{ .Get "src" }}" style="border-radius: 5px; max-width: 100%"
-     {{ else }}
-        src = "{{ .Get "src" }}" style="max-width: 100%"
-     {{ end }}
+<img src = "{{ .Get "src" }}" style="border-radius: 5px; max-width: 100%"
      {{ if .Get "alt" }}
         alt="{{ .Get "alt" }}" 
      {{ end }}

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.5",
+  "version": "2.0.6",
   "title": "GLightbox",
   "description": "Adds the ability to have simple, attractive lightbox and gallery for photos using a shortcode.",
   "includes": [


### PR DESCRIPTION
I dislike that Sunlit and the Micro.blog app show the thumbnailed images. I'm turning that off for actual size for now because the compression is pretty rough. I'm going to think about the need for thumbnailing or similarly different in the future to keep page loads down.