### PR TITLE
Alternative RSS rendering of gallery

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # News
 
+## Version 3.0.4
+
+* Adds alternative rendering of galleries in RSS to ensure image descriptions are properly displayed. Gallery images are now rendered within a `<figure>` element, with the image title and description appearing within a `<figcaption>` element.
+
 ## Version 3.0.3
 
 * Adjusts image gallery CSS to reduce margins added by `<p>` tags from using the render hook.

--- a/layouts/shortcodes/glightbox.xml
+++ b/layouts/shortcodes/glightbox.xml
@@ -1,0 +1,17 @@
+<figure>
+<img src="{{ .Get "src" }}"
+     {{ if .Get "alt" }}
+        alt="{{ .Get "alt" }}" 
+     {{ end }}
+     {{ if .Get "title" }}
+        title={{ .Get "title" }} 
+     {{ end }} />
+{{ if or (.Get "title") (.Get "description") }}
+  <figcaption>
+  {{ if .Get "title" }}
+    <strong>{{ .Get "title" }} {{ if .Get "description" }} — {{end}}</strong>
+  {{ end }}
+  {{ .Get "description" | default "" }}
+  </figcaption>
+{{end}}
+</figure>

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.3",
+  "version": "3.0.4",
   "title": "GLightbox",
   "description": "Adds the ability to have simple, attractive lightbox and gallery for photos using a shortcode.",
   "includes": [


### PR DESCRIPTION
Hi Json Becker,

I'd like to contribute a small change to glightbox that I've made on my blog. It's to deal with the issue where viewing a gallery made with this shortcode in RSS, the titles and descriptions get removed. I suspect this is because JavaScript is usually disabled, and Glightbox is not initialized.

This MR adds a new shortcode variant which will render the gallery differently in RSS, wrapping the image in a figure and adding a figcaption if the image has either a title or description. This will mean that the images are rendered in a single column, but I'm hoping that this will offset the loss of the titles and descriptions.

Let me know if this is of interest to you.

Thanks,

Leon